### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,10 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/dunuld/PlanningTool/security/code-scanning/4](https://github.com/dunuld/PlanningTool/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/maven.yml` at the workflow root (just under `name:` and before `on:`), so it applies to all jobs unless overridden.  
For this workflow, the best non-breaking minimal baseline is:

- `contents: read` (needed by `actions/checkout`)
- `packages: read` (safe for Maven/package reads and recommended read-only baseline)

This preserves current functionality while preventing unintended write access from default token settings. No imports, methods, or external definitions are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
